### PR TITLE
Fix location of Man Burns and Templel Burns labels

### DIFF
--- a/src/Controllers/BurnerVars.php
+++ b/src/Controllers/BurnerVars.php
@@ -75,8 +75,8 @@ class BurnerVars
             $ret .= '<option value="' . $simpleDateFormat . '" ' 
                 . (($currStage == 'Early') ? 'style="color: #999;"' : '')
                 . (($simpleDateFormat == $preSel) ? ' SELECTED ' : '') . '>' . date("D n/j", $currDate) 
-                . (($numSats == 2 && date("D", $currDate) == 'Sat') ? ' (Man Burns!)' : '')
-                . (($numSats == 2 && date("D", $currDate) == 'Sun') ? ' (Temple Burns!)' : '')
+                . (($numSats == 3 && date("D", $currDate) == 'Sat') ? ' (Man Burns!)' : '')
+                . (($numSats == 3 && date("D", $currDate) == 'Sun') ? ' (Temple Burns!)' : '')
                 . '</option>';
             if ($currDate == strtotime($this->mainDates[2])) {
                 $ret .= '<option DISABLED > </option><option DISABLED >---LATE DEPARTURE---</option>';


### PR DESCRIPTION
The number Saturdays iterates on the first Saturday which is prior to most WAPs and then labels last night of build and opening night as Man and Temple Burns respectively. Fixed it so it shows the actual dates the man and temple burns